### PR TITLE
add support for passing additional options to tftpd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN \
  groupmod -g 1000 users && \
  useradd -u 911 -U -d /config -s /bin/false nbxyz && \
  usermod -G users nbxyz && \
- mkdir /app \ 
+ mkdir /app \
        /config \
        /defaults && \
  if [ -z ${WEBAPP_VERSION+x} ]; then \
@@ -47,10 +47,11 @@ RUN \
  npm config set unsafe-perm true && \
  npm install --prefix /app
 
+ENV TFTPD_OPTS=''
+
 EXPOSE 3000
 
 COPY root/ /
 
 # default command
 CMD ["sh","/start.sh"]
-

--- a/root/etc/supervisor.conf
+++ b/root/etc/supervisor.conf
@@ -22,7 +22,7 @@ directory=/app
 priority = 3
 
 [program:in.tftpd]
-command=/usr/sbin/in.tftpd -Lvvv --user nbxyz --secure /config/menus
+command=/usr/sbin/in.tftpd -Lvvv --user nbxyz --secure %(ENV_TFTPD_OPTS)s /config/menus
 stdout_logfile=/config/tftpd.log
 redirect_stderr=true
 priority = 4


### PR DESCRIPTION
This adds support for passing additional options to `tftpd`, using environment variable `TFTPD_OPTS`.

Use case: on a machine with IPv6 disabled, `tftpd` fails to start unless using `--ipv4` option.