### PR TITLE
Make nginx port configurable through ENV variable. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN \
    bash \
    busybox \
    curl \
+   envsubst \
    git \
    jq \
    nghttp2-dev \
@@ -46,6 +47,7 @@ RUN \
  rm -rf /tmp/*
 
 ENV TFTPD_OPTS=''
+ENV NGINX_PORT='80'
 
 EXPOSE 3000
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ The following snippets are examples of starting up the container.
 docker run -d \
   --name=netbootxyz \
   -e MENU_VERSION=2.0.59             `# optional` \
+  -e NGINX_PORT=80                   `# optional` \
   -p 3000:3000                       `# sets webapp port` \
   -p 69:69/udp                       `# sets tftp port` \
-  -p 8080:80                         `# optional` \
+  -p 8080:80                         `# optional, destination should match ${NGINX_PORT} variable above.` \
   -v /local/path/to/config:/config   `# optional` \
   -v /local/path/to/assets:/assets   `# optional` \
   --restart unless-stopped \
@@ -138,7 +139,6 @@ INTERFACESv4="eth0"
 ```
 
 You'll also need a `/etc/dhcp/dhcpd.conf` looking something like this:
-
 
 ```shell
 option arch code 93 = unsigned integer 16;

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -6,11 +6,12 @@ services:
     container_name: netbootxyz
     environment:
       - MENU_VERSION=2.0.47 # optional
+      - NGINX_PORT=80 # optional
     volumes:
       - /path/to/config:/config # optional
       - /path/to/assets:/assets # optional
     ports:
       - 3000:3000
       - 69:69/udp
-      - 8080:80 #optional
+      - 8080:80 # optional, destination should match ${NGINX_PORT} variable above.
     restart: unless-stopped

--- a/root/defaults/default
+++ b/root/defaults/default
@@ -1,5 +1,5 @@
 server {
-	listen 80;
+	listen ${NGINX_PORT};
 	location / {
 		root /assets;
 		autoindex on;

--- a/root/start.sh
+++ b/root/start.sh
@@ -13,8 +13,8 @@ mkdir -p \
 [[ ! -f /config/nginx/nginx.conf ]] && \
   cp /defaults/nginx.conf /config/nginx/nginx.conf
 [[ ! -f /config/nginx/site-confs/default ]] && \
-  cp /defaults/default /config/nginx/site-confs/default
-  
+  envsubst < /defaults/default > /config/nginx/site-confs/default
+
 # Ownership
 chown -R nbxyz:nbxyz /assets
 chown -R nbxyz:nbxyz /var/lib/nginx
@@ -27,7 +27,7 @@ mkdir -p \
 
 # download menus if not found
 if [[ ! -f /config/menus/remote/menu.ipxe ]]; then
-  if [[ -z ${MENU_VERSION+x} ]]; then \
+  if [[ -z ${MENU_VERSION+x} ]]; then \ 
     MENU_VERSION=$(curl -sL "https://api.github.com/repos/netbootxyz/netboot.xyz/releases/latest" | jq -r '.tag_name')
   fi
   echo "[netbootxyz-init] Downloading netboot.xyz at ${MENU_VERSION}"


### PR DESCRIPTION
Closes #53

I did build the image and run against a docker host to make sure these changes work.

Default is still port 80, but now it can be overriden with ENV variable when needed.