### PR TITLE
Replace in.tftp server with dnsmasq, to add support for single-port TFTP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN \
    supervisor \
    syslog-ng \
    tar \
-   tftp-hpa && \
+   dnsmasq && \
  apk add --no-cache --virtual=build-dependencies \
    npm && \
  groupmod -g 1000 users && \

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e WEB_APP_PORT=3000` | Specify a different port for the web configuration interface to listen on. |
 | `-e NGINX_PORT=80` | Specify a different port for NGINX service to listen on. |
 | `-e MENU_VERSION=2.0.76` | Specify a specific version of boot files you want to use from netboot.xyz (unset pulls latest) |
+| `-e TFTPD_OPTS='--tftp-single-port'` | Specify arguments for the TFTP server (this example makes TFTP send all data over port 69) |
 | `-v /config` | Storage for boot menu files and web application config |
 | `-v /assets` | Storage for netboot.xyz bootable assets (live CDs and other files) |
 

--- a/root/etc/supervisor.conf
+++ b/root/etc/supervisor.conf
@@ -21,8 +21,8 @@ user=nbxyz
 directory=/app
 priority = 3
 
-[program:in.tftpd]
-command=/usr/sbin/in.tftpd -Lvvv --user nbxyz --secure %(ENV_TFTPD_OPTS)s /config/menus
+[program:dnsmasq]
+command=/usr/sbin/dnsmasq --port=0 --keep-in-foreground --enable-tftp --user=nbxyz --tftp-secure --tftp-root=/config/menus %(ENV_TFTPD_OPTS)s
 stdout_logfile=/config/tftpd.log
 redirect_stderr=true
 priority = 4


### PR DESCRIPTION
Dnsmasq provides TFTP server functionality that supports the optional `--tftp-single-port` argument.
Essentialy, when this flag is provided, all TFTP connections (not only the initial one) are performed over port `69`.
This makes it much easier to set up in environment with heavy NAT and/or firewall.
It comes in handy e.g. with the Kubernetes deployments.

Reasoning is basically the same as in [parallel PR](https://github.com/linuxserver/docker-netbootxyz/pull/40).

I've tested the changes in K8s environment (exposing only port 69 of the container) and with the example `docker-compose.yml`, connecting from a VM and a "real" device.

Also documenting the `TFTPD_OPTS` env variable.

The `--port=0` argument disables the built-in DNS server.

Oh, and thanks for providing nice software!