### PR TITLE
Add proxying to github for non-existing local assets

### DIFF
--- a/root/defaults/default
+++ b/root/defaults/default
@@ -2,6 +2,17 @@ server {
 	listen ${NGINX_PORT};
 	location / {
 		root /assets;
+		try_files $uri $uri/ @github;
 		autoindex on;
+	}
+
+	location @github {
+		rewrite ^ /netbootxyz$uri break;
+
+		proxy_buffer_size       128k;
+		proxy_buffers           4 256k;
+		proxy_busy_buffers_size 256k;
+
+		proxy_pass https://github.com;
 	}
 }


### PR DESCRIPTION
In the existing implementation, you need to cache all the possible assets locally, or you won't be able to use them. This PR adds a way for end-users to use locally cached assets and, at the same time, enjoy an occasional non-cached asset.

I'm unsure if including this change in the main docker image is worth it: adding a new docker tag for non-security cautious people/environments where this will be enabled might be a better idea. Or maybe setting up an nginx server on a different port just for that. Please advise how you would like to proceed here.

I'm using netboot.xyz in a tiny just-for-fun homelab environment, and I very much enjoy having a few most-used assets in the local cache and still being able to boot any other available thing :)