### PR TITLE
added redirect to pull non-existant local assets from live_endpoint url

### DIFF
--- a/root/defaults/default
+++ b/root/defaults/default
@@ -1,7 +1,16 @@
 server {
-	listen ${NGINX_PORT};
-	location / {
-		root /assets;
-		autoindex on;
-	}
+        listen ${NGINX_PORT};
+
+        set $v_filename nf;
+
+        location ~ ^/(.*)$ {
+                try_files $uri $uri/ @netboot;
+                set $v_filename $1;
+                root /assets;
+                autoindex on;
+        }
+
+        location @netboot {
+                return 302      https://github.com/netbootxyz/$v_filename;
+        }
 }


### PR DESCRIPTION
This PR implements #69

It achieves that the nginx can serve local assets as before, but it will send HTTP 302 redirects to the standard live_endpoint url for files that are NOT found locally. 
