### PR TITLE
Add proxy-DHCP support

### DIFF
--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -8,6 +8,7 @@ services:
       - MENU_VERSION=2.0.47 # optional
       - NGINX_PORT=80 # optional
       - WEB_APP_PORT=3000 # optional
+      - DHCP_RANGE_START=192.168.0.1 # optional, enables DHCP Proxy mode. set to your network's DHCP range first IP
     volumes:
       - /path/to/config:/config # optional
       - /path/to/assets:/assets # optional

--- a/root/defaults/dnsmasq-dhcpproxy.conf
+++ b/root/defaults/dnsmasq-dhcpproxy.conf
@@ -1,0 +1,66 @@
+# Only used if DHCP_RANGE_START is set, requires ENV vars changed via envsubst
+# DHCP Proxy range and enable verbose DHCP logging
+dhcp-range=${DHCP_RANGE_START},proxy
+log-dhcp
+leasefile-ro
+
+# Prevents reusing servername and filename fields to avoid confusing old clients
+dhcp-no-override
+
+# Disable multicast/broadcast discovery, and instruct client to download the boot file immediately
+dhcp-option=vendor:PXEClient,6,2b
+
+# Based on logic in https://gist.github.com/robinsmidsrod/4008017
+# iPXE sends a 175 option, checking suboptions
+dhcp-match=set:ipxe-http,175,19
+dhcp-match=set:ipxe-https,175,20
+dhcp-match=set:ipxe-menu,175,39
+# pcbios specific
+dhcp-match=set:ipxe-pxe,175,33
+dhcp-match=set:ipxe-bzimage,175,24
+dhcp-match=set:ipxe-iscsi,175,17
+# efi specific
+dhcp-match=set:ipxe-efi,175,36
+# combination
+# set ipxe-ok tag if we have correct combination
+# http && menu && iscsi ((pxe && bzimage) || efi)
+tag-if=set:ipxe-ok,tag:ipxe-http,tag:ipxe-menu,tag:ipxe-iscsi,tag:ipxe-pxe,tag:ipxe-bzimage
+tag-if=set:ipxe-ok,tag:ipxe-http,tag:ipxe-menu,tag:ipxe-iscsi,tag:ipxe-efi
+
+# Match BIOS PXE clients
+dhcp-match=set:bios,60,PXEClient:Arch:00000
+# Match UEFI 32-bit PXE clients
+dhcp-match=set:efi32,60,PXEClient:Arch:00002
+# Match UEFI 32-bit (variant 1) PXE clients
+dhcp-match=set:efi32-1,60,PXEClient:Arch:00006
+# Match UEFI 64-bit PXE clients
+dhcp-match=set:efi64,60,PXEClient:Arch:00007
+# Match UEFI 64-bit (variant 1) PXE clients
+dhcp-match=set:efi64-1,60,PXEClient:Arch:00008
+# Match UEFI 64-bit (BC variant) PXE clients
+dhcp-match=set:efi64-2,60,PXEClient:Arch:00009
+# Match ARM64 UEFI clients
+dhcp-match=set:arm64-efi,60,PXEClient:Arch:0000A
+# Match Raspberry Pi 4 (aarch64) architecture based on Option 60 (PXEClient vendor class)
+dhcp-match=set:rpi4,60,PXEClient:Arch:00011:UNDI:003000
+
+# Serve appropriate bootloaders for non-iPXE clients (initial PXE boot)
+# Legacy BIOS (not iPXE)
+pxe-service=tag:bios,tag:!ipxe-ok,X86PC,"Legacy BIOS",netboot.xyz-undionly.kpxe
+# UEFI 32-bit (not iPXE)
+pxe-service=tag:efi32,tag:!ipxe-ok,BC_EFI,"UEFI 32-bit",netboot.xyz.efi
+# UEFI 64-bit (not iPXE)
+pxe-service=tag:efi64,tag:!ipxe-ok,X86-64_EFI,"UEFI 64-bit",netboot.xyz.efi
+# ARM64 UEFI (not iPXE)
+pxe-service=tag:arm64-efi,tag:!ipxe-ok,ARM64_EFI,"ARM64 UEFI",netboot.xyz-arm64.efi
+# Raspberry Pi Boot (using rpi4 tag, not iPXE)
+pxe-service=tag:rpi4,tag:!ipxe-ok,0,"Raspberry Pi Boot",netboot.xyz-rpi4-snp.efi
+
+# DHCP Boot options for non-iPXE clients using envsubst for dynamic IP handling
+dhcp-boot=tag:bios,netboot.xyz.kpxe,,${CONTAINER_IP}
+dhcp-boot=tag:efi32,netboot.xyz.efi,,${CONTAINER_IP}
+dhcp-boot=tag:efi32-1,netboot.xyz.efi,,${CONTAINER_IP}
+dhcp-boot=tag:efi64,netboot.xyz.efi,,${CONTAINER_IP}
+dhcp-boot=tag:efi64-1,netboot.xyz.efi,,${CONTAINER_IP}
+dhcp-boot=tag:efi64-2,netboot.xyz.efi,,${CONTAINER_IP}
+dhcp-boot=tag:rpi4,netboot.xyz-rpi4-snp.efi,,${CONTAINER_IP}

--- a/root/defaults/dnsmasq.conf
+++ b/root/defaults/dnsmasq.conf
@@ -1,0 +1,5 @@
+# TFTP config
+enable-tftp
+user=nbxyz
+tftp-secure
+tftp-root=/config/menus

--- a/root/etc/supervisor.conf
+++ b/root/etc/supervisor.conf
@@ -22,7 +22,7 @@ directory=/app
 priority = 3
 
 [program:dnsmasq]
-command=/usr/sbin/dnsmasq --port=0 --keep-in-foreground --enable-tftp --user=nbxyz --tftp-secure --tftp-root=/config/menus %(ENV_TFTPD_OPTS)s
+command=/usr/sbin/dnsmasq --conf-file=/config/dnsmasq/dnsmasq.conf --port=0 --keep-in-foreground %(ENV_TFTPD_OPTS)s
 stdout_logfile=/config/tftpd.log
 redirect_stderr=true
 priority = 4

--- a/root/init.sh
+++ b/root/init.sh
@@ -16,9 +16,20 @@ mkdir -p \
 [[ ! -f /config/nginx/site-confs/default ]] &&
   envsubst </defaults/default >/config/nginx/site-confs/default
 
-# create dnsmasq config
+# create dnsmasq config, and conditionally add DHCP proxy support
 if [[ ! -f /config/dnsmasq/dnsmasq.conf ]]; then
   cp /defaults/dnsmasq.conf /config/dnsmasq/dnsmasq.conf
+
+  if [ -n "${DHCP_RANGE_START}" ]; then
+    echo "[netbootxyz-init] Enabling DHCP Proxy mode for DHCP_RANGE_START=${DHCP_RANGE_START}"
+
+    # Get the container's IP address using hostname if not already set
+    if [ -z "${CONTAINER_IP}" ]; then
+      CONTAINER_IP=$(hostname -i)
+      export CONTAINER_IP
+    fi
+    envsubst </defaults/dnsmasq-dhcpproxy.conf >>/config/dnsmasq/dnsmasq.conf
+  fi
 fi
 
 # Ownership

--- a/root/init.sh
+++ b/root/init.sh
@@ -5,15 +5,21 @@ mkdir -p \
   /assets \
   /config/nginx/site-confs \
   /config/log/nginx \
+  /config/dnsmasq \
   /run \
   /var/lib/nginx/tmp/client_body \
   /var/tmp/nginx
 
 # copy config files
-[[ ! -f /config/nginx/nginx.conf ]] && \
+[[ ! -f /config/nginx/nginx.conf ]] &&
   cp /defaults/nginx.conf /config/nginx/nginx.conf
-[[ ! -f /config/nginx/site-confs/default ]] && \
-  envsubst < /defaults/default > /config/nginx/site-confs/default
+[[ ! -f /config/nginx/site-confs/default ]] &&
+  envsubst </defaults/default >/config/nginx/site-confs/default
+
+# create dnsmasq config
+if [[ ! -f /config/dnsmasq/dnsmasq.conf ]]; then
+  cp /defaults/dnsmasq.conf /config/dnsmasq/dnsmasq.conf
+fi
 
 # Ownership
 chown -R nbxyz:nbxyz /assets
@@ -67,7 +73,7 @@ if [[ ! -f /config/menus/remote/menu.ipxe ]]; then
     /config/menus/remote/netboot.xyz-arm64-snponly.efi -sL \
     "https://github.com/netbootxyz/netboot.xyz/releases/download/${MENU_VERSION}/netboot.xyz-arm64-snponly.efi"
   # layer and cleanup
-  echo -n "${MENU_VERSION}" > /config/menuversion.txt
+  echo -n "${MENU_VERSION}" >/config/menuversion.txt
   cp -r /config/menus/remote/* /config/menus
   rm -f /tmp/menus.tar.gz
 fi


### PR DESCRIPTION
### This PR adds proxy-DHCP support:

- **What is proxy-DHCP?**  
  Proxy-DHCP allows a secondary DHCP server to provide boot configuration (such as next-server and boot file) while the primary DHCP server continues to assign IP addresses. This is useful in environments where modifying the primary DHCP server is not feasible, or the primary DHCP server doesn't have a static IP.

- **How proxy-DHCP works**  
  When a client sends out a DHCP request, the proxy-DHCP service will respond with boot options such as the next-server and boot filename, while leaving the IP address assignment to the primary DHCP server. This allows the client to chainload iPXE without requiring modifications to the existing DHCP server.

- **Pairs well with [netboot.xyz PR #953](https://github.com/netbootxyz/netboot.xyz/pull/953)**  
  This PR works alongside #953, which adds support for proxy-DHCP in the iPXE menus, allowing users to press a key to select the proxy offer and load netboot.xyz from there.

- **How to use it**  
  Set the `DHCP_RANGE_START` environment variable to the first IP in your network’s DHCP range. This will enable the optional proxy-DHCP mode. When enabled, dnsmasq calculates the range and handles proxy requests automatically.

- **Moved dnsmasq config to a file**  
  To enable this functionality cleanly, the dnsmasq configuration has been moved into a config file, allowing for different config based on the presence of env `DHCP_RANGE_START` and substitution of some values via envsubst.

- **Proxy-DHCP behaviour**  
  When `DHCP_RANGE_START` is set, the provided dnsmasq will behave in proxy-DHCP mode (in addition to tftp), with the following key sections in the configuration:
  
  ```bash
  # DHCP Proxy range and enable verbose DHCP logging
  dhcp-range=${DHCP_RANGE_START},proxy
  log-dhcp
  leasefile-ro

  # Detect iPXE requests via user class (Option 175)
  dhcp-match=set:ipxe-bios,175,33
  dhcp-match=set:ipxe-efi,175,36
  
  # Serve appropriate bootloaders for non-iPXE clients (initial PXE boot)
  pxe-service=tag:bios,tag:!ipxe-ok,X86PC,"Legacy BIOS",netboot.xyz-undionly.kpxe
  ...
  ```

  This configuration sets up the proxy-DHCP to respond only to PXE clients (non-iPXE), serving the appropriate bootloaders for BIOS, UEFI, ARM64, and Raspberry Pi clients, while iPXE clients will be served an HTTP boot script.

- **Dynamic IP handling with envsubst**  
  The `CONTAINER_IP` is dynamically injected into the configuration using `envsubst`, after retrieving the container’s IP address at runtime from the container itself via `init.sh`. This ensures that the correct container next-server IP is set in the configuration.

- **User experience**  
  Users can start the container with the relevant environment variables set (`DHCP_RANGE_START` and optionally others). When a DHCP request is detected, this container sends a proxy offer with the next-server and boot file. With PR [#953](https://github.com/netbootxyz/netboot.xyz/pull/953), netboot.xyz will detect the proxy next-server, allowing users to press `p` to boot from the proxy-DHCP server.

As it depends on a new env var being added `DHCP_RANGE_START`, this should be backwards compatible.

Docs & resources:
https://www.ipxe.org/appnote/proxydhcp
https://gist.github.com/NiKiZe/5c181471b96ac37a069af0a76688944d
https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html