### PR TITLE
Fix nginx permission error for log directory access

### DIFF
--- a/root/init.sh
+++ b/root/init.sh
@@ -29,6 +29,7 @@ mkdir -p \
   /config/nginx/site-confs \
   /config/log/nginx \
   /run \
+  /var/lib/nginx/logs \
   /var/lib/nginx/tmp/client_body \
   /var/tmp/nginx \
   /var/log
@@ -45,6 +46,7 @@ chown -R nbxyz:nbxyz /var/lib/nginx
 chown -R nbxyz:nbxyz /config/log/nginx
 chown -R nbxyz:nbxyz /run
 chown -R nbxyz:nbxyz /var/tmp/nginx
+chown -R nbxyz:nbxyz /var/log/nginx
 
 # create local logs dir
 mkdir -p \


### PR DESCRIPTION
## Summary
- Fixed nginx service failing to start due to permission denied errors on `/var/lib/nginx/logs/error.log`
- Added proper ownership setup for `/var/log/nginx` directory since `/var/lib/nginx/logs` is a symlink to it
- Ensures nginx can write logs when running as the `nbxyz` user

## Test plan
- [x] Built and tested Docker container locally
- [x] Verified nginx starts successfully without permission errors  
- [x] Confirmed all services (nginx, dnsmasq, webapp) are running properly