### PR TITLE
Fix CI build failure in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         fetch-depth: '0'
+        fetch-tags: true
         
     - name: Set env variables
       run: |
@@ -73,7 +74,7 @@ jobs:
         IMAGE_RELEASE=$(echo ${IMAGE_INFO} | jq -r '.Labels.build_version' | awk '{print $3}')
         IMAGE_VERSION=$(echo ${IMAGE_RELEASE} | awk -F'-nbxyz' '{print $1}')
         NB_RELEASE_NUMBER=$(echo ${IMAGE_RELEASE} | awk -F'-nbxyz' '{print $2}')
-        TAG_SHA=$(git rev-list -n 1 ${IMAGE_RELEASE})
+        TAG_SHA=$(git rev-list -n 1 ${IMAGE_RELEASE} 2>/dev/null || echo "")
         if [ -z "${MULTIDIGEST}" ] || [ "${MULTIDIGEST}" == "null" ]; then
           echo "**** No existing container build found, assuming first build ****"
           VERSION_TAG=${WEBAPP_RELEASE}-nbxyz1


### PR DESCRIPTION
## Summary
- Added `fetch-tags: true` to checkout action to ensure git tags are available during CI runs
- Added error handling to `git rev-list` command to prevent script failure when referenced tag doesn't exist

## Problem
The release workflow was failing with exit code 129 on the `git rev-list` command when trying to find commit SHA for version tags that weren't available in the CI environment.

## Solution
1. **Fetch tags explicitly**: Added `fetch-tags: true` to the checkout action to ensure all git tags are downloaded
2. **Error handling**: Modified the `git rev-list` command to gracefully handle missing tags by returning empty string instead of failing

## Test plan
- [x] Verified the workflow syntax is correct
- [x] Confirmed the error handling works locally
- [ ] Test in CI environment to ensure the build completes successfully