### PR TITLE
consider environment variable SUBFOLDER in healthcheck.sh

### DIFF
--- a/root/healthcheck.sh
+++ b/root/healthcheck.sh
@@ -13,7 +13,7 @@ if ! curl -fs http://127.0.0.1:${NGINX_PORT:-80}/ > /dev/null; then
 fi
 
 # Check Web App
-if ! curl -fs http://127.0.0.1:${WEB_APP_PORT:-3000}/ > /dev/null; then
+if ! curl -fs http://127.0.0.1:${WEB_APP_PORT:-3000}${SUBFOLDER:-/} > /dev/null; then
   echo "Web App check failed"
   exit 1
 fi


### PR DESCRIPTION
if we make use of environment variable SUBFOLDER in container deployment, container healthcheck never goes green because a wrong path will be checked.

Tested with:
```yaml
    environment:
        - SUBFOLDER=/nbx/
```
if we use `${SUBFOLDER:-/}` instead of a plain `/` in `# Check Web App` section, the healthcheck will succeed.
