### PR TITLE
Add UEFI Secure Boot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,4 +269,4 @@ dhcp-boot=tag:efi-arm64-sb,secureboot-arm64/shimaa64.efi,,SERVER_IP_ADDRESS
 
 All files within a Secure Boot directory must remain together in the same TFTP path since the shim expects to find iPXE and the `autoexec.ipxe` script alongside it.
 
-> **Note:** Secure Boot support requires a netboot.xyz release that includes `autoexec.ipxe`. If you pin `MENU_VERSION` to an older release, the Secure Boot binaries will still be downloaded from iPXE but the boot script will be missing and a warning will be logged.
+> **Note:** Secure Boot files are downloaded independently of the menu files. Existing installs will automatically pick up Secure Boot binaries on the next container restart. The `autoexec.ipxe` boot script requires a netboot.xyz release that includes it — if `MENU_VERSION` points to an older release, the signed binaries will still be downloaded but the boot script will be missing and a warning will be logged.

--- a/README.md
+++ b/README.md
@@ -230,7 +230,12 @@ The following bootfile names can be set as the boot file in the DHCP configurati
 
 ## UEFI Secure Boot
 
-The container automatically downloads Microsoft-signed iPXE Secure Boot binaries from netboot.xyz releases. These are placed in subdirectories under `/config/menus/`:
+The container supports UEFI Secure Boot by downloading:
+
+- **Signed iPXE binaries** directly from the upstream [iPXE project release](https://github.com/ipxe/ipxe/releases) (`ipxeboot.tar.gz`). These are **unmodified** pre-built binaries from iPXE; netboot.xyz does not rebuild or alter them in any way. The default version is `v2.0.0` and can be overridden with the `IPXE_SB_VERSION` environment variable.
+- **`autoexec.ipxe`** boot script from the [netboot.xyz release](https://github.com/netbootxyz/netboot.xyz/releases), which chains into the netboot.xyz menu system.
+
+These are placed in subdirectories under `/config/menus/`:
 
 | directory | description |
 | ----------|-------------|
@@ -239,14 +244,14 @@ The container automatically downloads Microsoft-signed iPXE Secure Boot binaries
 
 Each directory contains:
 
-| file | description |
-| -----|-------------|
-| `shimx64.efi` / `shimaa64.efi` | Microsoft-signed shim (UEFI firmware entry point) |
-| `ipxe-shim.efi` | iPXE shim, loads iPXE with built-in NIC drivers |
-| `ipxe.efi` | iPXE binary signed by iPXE Secure Boot CA |
-| `snponly.efi` | SNP-only iPXE, boots from chained device only |
-| `snponly-shim.efi` | Shim for SNP-only iPXE |
-| `autoexec.ipxe` | Boot script that chains into the netboot.xyz menu system |
+| file | source | description |
+| -----|--------|-------------|
+| `shimx64.efi` / `shimaa64.efi` | iPXE release | Microsoft-signed shim (UEFI firmware entry point) |
+| `ipxe-shim.efi` | iPXE release | iPXE shim, loads iPXE with built-in NIC drivers |
+| `ipxe.efi` | iPXE release | iPXE binary signed by iPXE Secure Boot CA |
+| `snponly.efi` | iPXE release | SNP-only iPXE, boots from chained device only |
+| `snponly-shim.efi` | iPXE release | Shim for SNP-only iPXE |
+| `autoexec.ipxe` | netboot.xyz release | Boot script that chains into the netboot.xyz menu system |
 
 The boot flow is: UEFI firmware validates the Microsoft-signed shim, which loads iPXE (signed by iPXE Secure Boot CA), which auto-loads `autoexec.ipxe` (text script, no Secure Boot validation needed), which chains to the netboot.xyz menu.
 
@@ -264,4 +269,4 @@ dhcp-boot=tag:efi-arm64-sb,secureboot-arm64/shimaa64.efi,,SERVER_IP_ADDRESS
 
 All files within a Secure Boot directory must remain together in the same TFTP path since the shim expects to find iPXE and the `autoexec.ipxe` script alongside it.
 
-> **Note:** Secure Boot binaries are only available from netboot.xyz releases that include them. If you pin `MENU_VERSION` to an older release, the Secure Boot files will not be downloaded and a warning will be logged.
+> **Note:** Secure Boot support requires a netboot.xyz release that includes `autoexec.ipxe`. If you pin `MENU_VERSION` to an older release, the Secure Boot binaries will still be downloaded from iPXE but the boot script will be missing and a warning will be logged.

--- a/README.md
+++ b/README.md
@@ -227,3 +227,41 @@ The following bootfile names can be set as the boot file in the DHCP configurati
 | `netboot.xyz-arm64-snp.efi` | UEFI w/ Simple Network Protocol, attempts to boot all net devices |
 | `netboot.xyz-arm64-snponly.efi` | UEFI w/ Simple Network Protocol, only boots from device chained from |
 | `netboot.xyz-rpi4-snp.efi` | UEFI for Raspberry Pi 4, attempts to boot all net devices |
+
+## UEFI Secure Boot
+
+The container automatically downloads Microsoft-signed iPXE Secure Boot binaries from netboot.xyz releases. These are placed in subdirectories under `/config/menus/`:
+
+| directory | description |
+| ----------|-------------|
+| `secureboot-x86_64/` | x86_64 UEFI Secure Boot binaries |
+| `secureboot-arm64/` | ARM64 UEFI Secure Boot binaries |
+
+Each directory contains:
+
+| file | description |
+| -----|-------------|
+| `shimx64.efi` / `shimaa64.efi` | Microsoft-signed shim (UEFI firmware entry point) |
+| `ipxe-shim.efi` | iPXE shim, loads iPXE with built-in NIC drivers |
+| `ipxe.efi` | iPXE binary signed by iPXE Secure Boot CA |
+| `snponly.efi` | SNP-only iPXE, boots from chained device only |
+| `snponly-shim.efi` | Shim for SNP-only iPXE |
+| `autoexec.ipxe` | Boot script that chains into the netboot.xyz menu system |
+
+The boot flow is: UEFI firmware validates the Microsoft-signed shim, which loads iPXE (signed by iPXE Secure Boot CA), which auto-loads `autoexec.ipxe` (text script, no Secure Boot validation needed), which chains to the netboot.xyz menu.
+
+To use Secure Boot with DHCP/TFTP, point your DHCP server to the shim as the boot file:
+
+```shell
+# 64-bit x86 EFI with Secure Boot
+dhcp-match=set:efi64-sb,60,PXEClient:Arch:00007
+dhcp-boot=tag:efi64-sb,secureboot-x86_64/shimx64.efi,,SERVER_IP_ADDRESS
+
+# 64-bit ARM64 UEFI with Secure Boot
+dhcp-match=set:efi-arm64-sb,60,PXEClient:Arch:0000B
+dhcp-boot=tag:efi-arm64-sb,secureboot-arm64/shimaa64.efi,,SERVER_IP_ADDRESS
+```
+
+All files within a Secure Boot directory must remain together in the same TFTP path since the shim expects to find iPXE and the `autoexec.ipxe` script alongside it.
+
+> **Note:** Secure Boot binaries are only available from netboot.xyz releases that include them. If you pin `MENU_VERSION` to an older release, the Secure Boot files will not be downloaded and a warning will be logged.

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,17 @@
 {
   "extends": [
     "config:base"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track iPXE Secure Boot release version pinned in init.sh",
+      "fileMatch": ["root/init\\.sh"],
+      "matchStrings": [
+        "IPXE_SB_VERSION=\"\\$\\{IPXE_SB_VERSION:-(?<currentValue>v[\\d.]+)\\}\""
+      ],
+      "depNameTemplate": "ipxe/ipxe",
+      "datasourceTemplate": "github-releases"
+    }
   ]
 }

--- a/root/init.sh
+++ b/root/init.sh
@@ -94,27 +94,50 @@ if [[ ! -f /config/menus/remote/menu.ipxe ]]; then
   curl -o \
     /config/menus/remote/netboot.xyz-arm64-snponly.efi -sL \
     "https://github.com/netbootxyz/netboot.xyz/releases/download/${MENU_VERSION}/netboot.xyz-arm64-snponly.efi"
-  # secure boot files
-  echo "[netbootxyz-init] Downloading Secure Boot binaries..."
+  # Secure Boot files:
+  # - Signed EFI binaries are downloaded unmodified from the upstream iPXE
+  #   project release at https://github.com/ipxe/ipxe/releases (ipxeboot.tar.gz).
+  #   These include the Microsoft-signed shim and iPXE binaries signed by the
+  #   iPXE Secure Boot CA. They are not rebuilt or altered by netboot.xyz.
+  # - The autoexec.ipxe boot script is downloaded from the netboot.xyz release.
+  #   It is the only netboot.xyz-produced artifact in the Secure Boot chain.
+  # - IPXE_SB_VERSION can be overridden to pin a specific iPXE release version.
+  IPXE_SB_VERSION="${IPXE_SB_VERSION:-v2.0.0}"
+  echo "[netbootxyz-init] Downloading Secure Boot binaries (iPXE ${IPXE_SB_VERSION})..."
   curl -o \
-    /tmp/secureboot-x86_64.tar.gz -sL \
-    "https://github.com/netbootxyz/netboot.xyz/releases/download/${MENU_VERSION}/secureboot-x86_64.tar.gz"
-  if [ -f /tmp/secureboot-x86_64.tar.gz ] && [ -s /tmp/secureboot-x86_64.tar.gz ]; then
-    tar xf /tmp/secureboot-x86_64.tar.gz -C /config/menus/remote
+    /tmp/ipxeboot.tar.gz -sL \
+    "https://github.com/ipxe/ipxe/releases/download/${IPXE_SB_VERSION}/ipxeboot.tar.gz"
+  if [[ -f /tmp/ipxeboot.tar.gz ]] && [[ -s /tmp/ipxeboot.tar.gz ]]; then
+    mkdir -p \
+      /config/menus/remote/secureboot-x86_64 \
+      /config/menus/remote/secureboot-arm64
+    tar xf /tmp/ipxeboot.tar.gz -C /tmp
+    # x86_64 secure boot binaries
+    for f in shimx64.efi ipxe-shim.efi ipxe.efi snponly.efi snponly-shim.efi; do
+      cp "/tmp/ipxeboot/x86_64-sb/${f}" /config/menus/remote/secureboot-x86_64/
+    done
+    # arm64 secure boot binaries
+    for f in shimaa64.efi ipxe-shim.efi ipxe.efi snponly.efi snponly-shim.efi; do
+      cp "/tmp/ipxeboot/arm64-sb/${f}" /config/menus/remote/secureboot-arm64/
+    done
+    rm -rf /tmp/ipxeboot /tmp/ipxeboot.tar.gz
+    # download autoexec.ipxe boot script from netboot.xyz release
+    curl -o \
+      /tmp/autoexec.ipxe -sL \
+      "https://github.com/netbootxyz/netboot.xyz/releases/download/${MENU_VERSION}/autoexec.ipxe"
+    if [[ -f /tmp/autoexec.ipxe ]] && [[ -s /tmp/autoexec.ipxe ]]; then
+      cp /tmp/autoexec.ipxe /config/menus/remote/secureboot-x86_64/autoexec.ipxe
+      cp /tmp/autoexec.ipxe /config/menus/remote/secureboot-arm64/autoexec.ipxe
+      rm -f /tmp/autoexec.ipxe
+    else
+      echo "[netbootxyz-init] autoexec.ipxe not available for ${MENU_VERSION}, skipping"
+    fi
   else
-    echo "[netbootxyz-init] Secure Boot x86_64 tarball not available for ${MENU_VERSION}, skipping"
-  fi
-  curl -o \
-    /tmp/secureboot-arm64.tar.gz -sL \
-    "https://github.com/netbootxyz/netboot.xyz/releases/download/${MENU_VERSION}/secureboot-arm64.tar.gz"
-  if [ -f /tmp/secureboot-arm64.tar.gz ] && [ -s /tmp/secureboot-arm64.tar.gz ]; then
-    tar xf /tmp/secureboot-arm64.tar.gz -C /config/menus/remote
-  else
-    echo "[netbootxyz-init] Secure Boot ARM64 tarball not available for ${MENU_VERSION}, skipping"
+    echo "[netbootxyz-init] iPXE Secure Boot archive not available, skipping"
   fi
   # cleanup
   echo -n "${MENU_VERSION}" > /config/menuversion.txt
-  rm -f /tmp/menus.tar.gz /tmp/secureboot-*.tar.gz
+  rm -f /tmp/menus.tar.gz
 fi
 
 # Apply menu layering: remote files first, then local overrides on top

--- a/root/init.sh
+++ b/root/init.sh
@@ -94,10 +94,45 @@ if [[ ! -f /config/menus/remote/menu.ipxe ]]; then
   curl -o \
     /config/menus/remote/netboot.xyz-arm64-snponly.efi -sL \
     "https://github.com/netbootxyz/netboot.xyz/releases/download/${MENU_VERSION}/netboot.xyz-arm64-snponly.efi"
-  # layer and cleanup
+  # secure boot files
+  echo "[netbootxyz-init] Downloading Secure Boot binaries..."
+  curl -o \
+    /tmp/secureboot-x86_64.tar.gz -sL \
+    "https://github.com/netbootxyz/netboot.xyz/releases/download/${MENU_VERSION}/secureboot-x86_64.tar.gz"
+  if [ -f /tmp/secureboot-x86_64.tar.gz ] && [ -s /tmp/secureboot-x86_64.tar.gz ]; then
+    tar xf /tmp/secureboot-x86_64.tar.gz -C /config/menus/remote
+  else
+    echo "[netbootxyz-init] Secure Boot x86_64 tarball not available for ${MENU_VERSION}, skipping"
+  fi
+  curl -o \
+    /tmp/secureboot-arm64.tar.gz -sL \
+    "https://github.com/netbootxyz/netboot.xyz/releases/download/${MENU_VERSION}/secureboot-arm64.tar.gz"
+  if [ -f /tmp/secureboot-arm64.tar.gz ] && [ -s /tmp/secureboot-arm64.tar.gz ]; then
+    tar xf /tmp/secureboot-arm64.tar.gz -C /config/menus/remote
+  else
+    echo "[netbootxyz-init] Secure Boot ARM64 tarball not available for ${MENU_VERSION}, skipping"
+  fi
+  # cleanup
   echo -n "${MENU_VERSION}" > /config/menuversion.txt
-  cp -r /config/menus/remote/* /config/menus
-  rm -f /tmp/menus.tar.gz
+  rm -f /tmp/menus.tar.gz /tmp/secureboot-*.tar.gz
+fi
+
+# Apply menu layering: remote files first, then local overrides on top
+# This mirrors the webapp's layermenu() function and ensures user
+# customizations (boot.cfg, local-vars.ipxe, etc.) persist across
+# container restarts
+echo "[netbootxyz-init] Applying menu layers..."
+for file in /config/menus/remote/*; do
+  [ -f "$file" ] && cp "$file" /config/menus/
+done
+# Copy Secure Boot subdirectories if present
+for sbdir in /config/menus/remote/secureboot-*/; do
+  [ -d "$sbdir" ] && cp -r "$sbdir" /config/menus/
+done
+if [ -d /config/menus/local ]; then
+  for file in /config/menus/local/*; do
+    [ -f "$file" ] && cp "$file" /config/menus/
+  done
 fi
 
 # Ownership

--- a/root/init.sh
+++ b/root/init.sh
@@ -108,30 +108,41 @@ if [[ ! -f /config/menus/remote/menu.ipxe ]]; then
     /tmp/ipxeboot.tar.gz -sL \
     "https://github.com/ipxe/ipxe/releases/download/${IPXE_SB_VERSION}/ipxeboot.tar.gz"
   if [[ -f /tmp/ipxeboot.tar.gz ]] && [[ -s /tmp/ipxeboot.tar.gz ]]; then
-    mkdir -p \
-      /config/menus/remote/secureboot-x86_64 \
-      /config/menus/remote/secureboot-arm64
-    tar xf /tmp/ipxeboot.tar.gz -C /tmp
-    # x86_64 secure boot binaries
-    for f in shimx64.efi ipxe-shim.efi ipxe.efi snponly.efi snponly-shim.efi; do
-      cp "/tmp/ipxeboot/x86_64-sb/${f}" /config/menus/remote/secureboot-x86_64/
-    done
-    # arm64 secure boot binaries
-    for f in shimaa64.efi ipxe-shim.efi ipxe.efi snponly.efi snponly-shim.efi; do
-      cp "/tmp/ipxeboot/arm64-sb/${f}" /config/menus/remote/secureboot-arm64/
-    done
-    rm -rf /tmp/ipxeboot /tmp/ipxeboot.tar.gz
-    # download autoexec.ipxe boot script from netboot.xyz release
-    curl -o \
-      /tmp/autoexec.ipxe -sL \
-      "https://github.com/netbootxyz/netboot.xyz/releases/download/${MENU_VERSION}/autoexec.ipxe"
-    if [[ -f /tmp/autoexec.ipxe ]] && [[ -s /tmp/autoexec.ipxe ]]; then
-      cp /tmp/autoexec.ipxe /config/menus/remote/secureboot-x86_64/autoexec.ipxe
-      cp /tmp/autoexec.ipxe /config/menus/remote/secureboot-arm64/autoexec.ipxe
-      rm -f /tmp/autoexec.ipxe
+    if tar xf /tmp/ipxeboot.tar.gz -C /tmp; then
+      mkdir -p \
+        /config/menus/remote/secureboot-x86_64 \
+        /config/menus/remote/secureboot-arm64
+      # x86_64 secure boot binaries
+      for f in shimx64.efi ipxe-shim.efi ipxe.efi snponly.efi snponly-shim.efi; do
+        if [[ -f "/tmp/ipxeboot/x86_64-sb/${f}" ]]; then
+          cp "/tmp/ipxeboot/x86_64-sb/${f}" /config/menus/remote/secureboot-x86_64/
+        else
+          echo "[netbootxyz-init] Warning: ${f} not found in iPXE x86_64-sb archive"
+        fi
+      done
+      # arm64 secure boot binaries
+      for f in shimaa64.efi ipxe-shim.efi ipxe.efi snponly.efi snponly-shim.efi; do
+        if [[ -f "/tmp/ipxeboot/arm64-sb/${f}" ]]; then
+          cp "/tmp/ipxeboot/arm64-sb/${f}" /config/menus/remote/secureboot-arm64/
+        else
+          echo "[netbootxyz-init] Warning: ${f} not found in iPXE arm64-sb archive"
+        fi
+      done
+      # download autoexec.ipxe boot script from netboot.xyz release
+      curl -o \
+        /tmp/autoexec.ipxe -sL \
+        "https://github.com/netbootxyz/netboot.xyz/releases/download/${MENU_VERSION}/autoexec.ipxe"
+      if [[ -f /tmp/autoexec.ipxe ]] && [[ -s /tmp/autoexec.ipxe ]]; then
+        cp /tmp/autoexec.ipxe /config/menus/remote/secureboot-x86_64/autoexec.ipxe
+        cp /tmp/autoexec.ipxe /config/menus/remote/secureboot-arm64/autoexec.ipxe
+        rm -f /tmp/autoexec.ipxe
+      else
+        echo "[netbootxyz-init] autoexec.ipxe not available for ${MENU_VERSION}, skipping"
+      fi
     else
-      echo "[netbootxyz-init] autoexec.ipxe not available for ${MENU_VERSION}, skipping"
+      echo "[netbootxyz-init] Failed to extract iPXE Secure Boot archive, skipping"
     fi
+    rm -rf /tmp/ipxeboot /tmp/ipxeboot.tar.gz
   else
     echo "[netbootxyz-init] iPXE Secure Boot archive not available, skipping"
   fi
@@ -149,9 +160,11 @@ for file in /config/menus/remote/*; do
   [ -f "$file" ] && cp "$file" /config/menus/
 done
 # Copy Secure Boot subdirectories if present
+shopt -s nullglob
 for sbdir in /config/menus/remote/secureboot-*/; do
-  [ -d "$sbdir" ] && cp -r "$sbdir" /config/menus/
+  cp -r "$sbdir" /config/menus/
 done
+shopt -u nullglob
 if [ -d /config/menus/local ]; then
   for file in /config/menus/local/*; do
     [ -f "$file" ] && cp "$file" /config/menus/

--- a/root/init.sh
+++ b/root/init.sh
@@ -53,11 +53,17 @@ mkdir -p \
   /config/menus/remote \
   /config/menus/local
 
-# download menus if not found
-if [[ ! -f /config/menus/remote/menu.ipxe ]]; then
-  if [[ -z ${MENU_VERSION+x} ]]; then
+# resolve menu version once for use by both menu and secure boot downloads
+if [[ -z ${MENU_VERSION+x} ]]; then
+  if [[ -f /config/menuversion.txt ]]; then
+    MENU_VERSION=$(cat /config/menuversion.txt)
+  else
     MENU_VERSION=$(curl -sL "https://api.github.com/repos/netbootxyz/netboot.xyz/releases/latest" | jq -r '.tag_name')
   fi
+fi
+
+# download menus if not found
+if [[ ! -f /config/menus/remote/menu.ipxe ]]; then
   echo "[netbootxyz-init] Downloading netboot.xyz at ${MENU_VERSION}"
   # menu files
   curl -o \
@@ -94,14 +100,20 @@ if [[ ! -f /config/menus/remote/menu.ipxe ]]; then
   curl -o \
     /config/menus/remote/netboot.xyz-arm64-snponly.efi -sL \
     "https://github.com/netbootxyz/netboot.xyz/releases/download/${MENU_VERSION}/netboot.xyz-arm64-snponly.efi"
-  # Secure Boot files:
-  # - Signed EFI binaries are downloaded unmodified from the upstream iPXE
-  #   project release at https://github.com/ipxe/ipxe/releases (ipxeboot.tar.gz).
-  #   These include the Microsoft-signed shim and iPXE binaries signed by the
-  #   iPXE Secure Boot CA. They are not rebuilt or altered by netboot.xyz.
-  # - The autoexec.ipxe boot script is downloaded from the netboot.xyz release.
-  #   It is the only netboot.xyz-produced artifact in the Secure Boot chain.
-  # - IPXE_SB_VERSION can be overridden to pin a specific iPXE release version.
+  # cleanup
+  echo -n "${MENU_VERSION}" > /config/menuversion.txt
+  rm -f /tmp/menus.tar.gz
+fi
+
+# Secure Boot files (runs independently of menu download):
+# - Signed EFI binaries are downloaded unmodified from the upstream iPXE
+#   project release at https://github.com/ipxe/ipxe/releases (ipxeboot.tar.gz).
+#   These include the Microsoft-signed shim and iPXE binaries signed by the
+#   iPXE Secure Boot CA. They are not rebuilt or altered by netboot.xyz.
+# - The autoexec.ipxe boot script is downloaded from the netboot.xyz release.
+#   It is the only netboot.xyz-produced artifact in the Secure Boot chain.
+# - IPXE_SB_VERSION can be overridden to pin a specific iPXE release version.
+if [[ ! -d /config/menus/remote/secureboot-x86_64 ]]; then
   IPXE_SB_VERSION="${IPXE_SB_VERSION:-v2.0.0}"
   echo "[netbootxyz-init] Downloading Secure Boot binaries (iPXE ${IPXE_SB_VERSION})..."
   curl -o \
@@ -129,10 +141,8 @@ if [[ ! -f /config/menus/remote/menu.ipxe ]]; then
         fi
       done
       # download autoexec.ipxe boot script from netboot.xyz release
-      curl -o \
-        /tmp/autoexec.ipxe -sL \
-        "https://github.com/netbootxyz/netboot.xyz/releases/download/${MENU_VERSION}/autoexec.ipxe"
-      if [[ -f /tmp/autoexec.ipxe ]] && [[ -s /tmp/autoexec.ipxe ]]; then
+      if curl -o /tmp/autoexec.ipxe -fsSL \
+        "https://github.com/netbootxyz/netboot.xyz/releases/download/${MENU_VERSION}/autoexec.ipxe"; then
         cp /tmp/autoexec.ipxe /config/menus/remote/secureboot-x86_64/autoexec.ipxe
         cp /tmp/autoexec.ipxe /config/menus/remote/secureboot-arm64/autoexec.ipxe
         rm -f /tmp/autoexec.ipxe
@@ -146,9 +156,6 @@ if [[ ! -f /config/menus/remote/menu.ipxe ]]; then
   else
     echo "[netbootxyz-init] iPXE Secure Boot archive not available, skipping"
   fi
-  # cleanup
-  echo -n "${MENU_VERSION}" > /config/menuversion.txt
-  rm -f /tmp/menus.tar.gz
 fi
 
 # Apply menu layering: remote files first, then local overrides on top

--- a/root/init.sh
+++ b/root/init.sh
@@ -100,8 +100,9 @@ if [[ ! -f /config/menus/remote/menu.ipxe ]]; then
   curl -o \
     /config/menus/remote/netboot.xyz-arm64-snponly.efi -sL \
     "https://github.com/netbootxyz/netboot.xyz/releases/download/${MENU_VERSION}/netboot.xyz-arm64-snponly.efi"
-  # cleanup
+  # layer and cleanup
   echo -n "${MENU_VERSION}" > /config/menuversion.txt
+  cp -r /config/menus/remote/* /config/menus
   rm -f /tmp/menus.tar.gz
 fi
 
@@ -149,6 +150,12 @@ if [[ ! -d /config/menus/remote/secureboot-x86_64 ]]; then
       else
         echo "[netbootxyz-init] autoexec.ipxe not available for ${MENU_VERSION}, skipping"
       fi
+      # layer Secure Boot directories into /config/menus
+      shopt -s nullglob
+      for sbdir in /config/menus/remote/secureboot-*/; do
+        cp -r "$sbdir" /config/menus/
+      done
+      shopt -u nullglob
     else
       echo "[netbootxyz-init] Failed to extract iPXE Secure Boot archive, skipping"
     fi
@@ -156,26 +163,6 @@ if [[ ! -d /config/menus/remote/secureboot-x86_64 ]]; then
   else
     echo "[netbootxyz-init] iPXE Secure Boot archive not available, skipping"
   fi
-fi
-
-# Apply menu layering: remote files first, then local overrides on top
-# This mirrors the webapp's layermenu() function and ensures user
-# customizations (boot.cfg, local-vars.ipxe, etc.) persist across
-# container restarts
-echo "[netbootxyz-init] Applying menu layers..."
-for file in /config/menus/remote/*; do
-  [ -f "$file" ] && cp "$file" /config/menus/
-done
-# Copy Secure Boot subdirectories if present
-shopt -s nullglob
-for sbdir in /config/menus/remote/secureboot-*/; do
-  cp -r "$sbdir" /config/menus/
-done
-shopt -u nullglob
-if [ -d /config/menus/local ]; then
-  for file in /config/menus/local/*; do
-    [ -f "$file" ] && cp "$file" /config/menus/
-  done
 fi
 
 # Ownership


### PR DESCRIPTION
## Summary
- Downloads UEFI Secure Boot signed binaries **unmodified** from the upstream [iPXE v2.0.0 release](https://github.com/ipxe/ipxe/releases/tag/v2.0.0) (`ipxeboot.tar.gz`)
- Downloads the `autoexec.ipxe` boot script from the [netboot.xyz release](https://github.com/netbootxyz/netboot.xyz/releases) — this is the only netboot.xyz-produced artifact in the Secure Boot chain
- Extracts into `/config/menus/secureboot-{x86_64,arm64}/` and serves via TFTP
- iPXE Secure Boot version defaults to `v2.0.0`, overridable via `IPXE_SB_VERSION` env var
- Gracefully skips if either download is unavailable (older `MENU_VERSION` or network issues)

## Provenance
The signed EFI binaries (Microsoft-signed shim, iPXE Secure Boot CA-signed iPXE) are pulled directly from the iPXE project's GitHub release and are not rebuilt, repackaged, or modified by netboot.xyz. This is documented in both `init.sh` comments and the README.

## Boot flow
```
UEFI firmware → shimx64.efi (Microsoft-signed, from iPXE release)
  → ipxe.efi (signed by iPXE Secure Boot CA, from iPXE release)
    → autoexec.ipxe (from netboot.xyz release, chains to menu)
      → https://boot.netboot.xyz/menu.ipxe
```

## DHCP configuration
```
dhcp-boot=tag:efi64,secureboot-x86_64/shimx64.efi,,SERVER_IP_ADDRESS
```

## Dependencies
Requires the companion PR in netboot.xyz to publish `autoexec.ipxe` as a release asset: https://github.com/netbootxyz/netboot.xyz/pull/1759

## Files changed
- `root/init.sh` — Secure Boot download/extraction logic with provenance documentation
- `README.md` — Secure Boot section with upstream source attribution, file table, and DHCP examples