### PR TITLE
Skip image publish for fork PRs; document maintainer builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
     outputs:
       tag_suffix: ${{ steps.tags.outputs.tag_suffix }}
       is_pr: ${{ steps.tags.outputs.is_pr }}
+      is_fork: ${{ steps.tags.outputs.is_fork }}
       webapp_release: ${{ steps.webapp.outputs.webapp_release }}
       build_date: ${{ steps.tags.outputs.build_date }}
     steps:
@@ -36,10 +37,17 @@ jobs:
         EVENT_NAME: ${{ github.event_name }}
         PR_NUMBER: ${{ github.event.number }}
         INPUT_TAG_SUFFIX: ${{ github.event.inputs.tag_suffix }}
+        HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        BASE_REPO: ${{ github.repository }}
       run: |
         if [ "$EVENT_NAME" == "pull_request" ]; then
           echo "tag_suffix=pr-${PR_NUMBER}" >> $GITHUB_OUTPUT
           echo "is_pr=true" >> $GITHUB_OUTPUT
+          if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "is_fork=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_fork=false" >> $GITHUB_OUTPUT
+          fi
         elif [ "$EVENT_NAME" == "workflow_dispatch" ]; then
           if [ -n "$INPUT_TAG_SUFFIX" ]; then
             SANITIZED=$(echo "$INPUT_TAG_SUFFIX" | tr -cd '[:alnum:]-_' | cut -c1-50)
@@ -52,6 +60,7 @@ jobs:
             echo "tag_suffix=test-$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
           fi
           echo "is_pr=false" >> $GITHUB_OUTPUT
+          echo "is_fork=false" >> $GITHUB_OUTPUT
         else
           echo "::error::Unsupported event type: $EVENT_NAME"
           exit 1
@@ -71,12 +80,14 @@ jobs:
       uses: docker/setup-buildx-action@v4
 
     - name: Login to the Docker Container Registry
+      if: needs.setup.outputs.is_fork != 'true'
       uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Login to the GitHub Container Registry
+      if: needs.setup.outputs.is_fork != 'true'
       uses: docker/login-action@v4
       with:
         registry: ghcr.io
@@ -84,6 +95,7 @@ jobs:
         password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Build and push (amd64)
+      if: needs.setup.outputs.is_fork != 'true'
       id: build
       uses: docker/build-push-action@v7
       with:
@@ -102,13 +114,31 @@ jobs:
           org.opencontainers.image.source=https://github.com/netbootxyz/docker-netbootxyz
         outputs: type=image,name=ghcr.io/netbootxyz/netbootxyz,push-by-digest=true,name-canonical=true,push=true
 
+    # Fork PRs cannot access registry secrets — verify the Dockerfile builds
+    # cleanly without pushing. Maintainers can manually trigger a publishing
+    # build via workflow_dispatch after reviewing the PR.
+    - name: Build (amd64, fork PR — no push)
+      if: needs.setup.outputs.is_fork == 'true'
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/amd64
+        push: false
+        build-args: |
+          WEBAPP_VERSION=${{ needs.setup.outputs.webapp_release }}
+          VERSION=${{ needs.setup.outputs.tag_suffix }}
+          BUILD_DATE=${{ needs.setup.outputs.build_date }}
+
     - name: Export digest
+      if: needs.setup.outputs.is_fork != 'true'
       run: |
         mkdir -p /tmp/digests
         digest="${{ steps.build.outputs.digest }}"
         touch "/tmp/digests/${digest#sha256:}"
 
     - name: Upload digest
+      if: needs.setup.outputs.is_fork != 'true'
       uses: actions/upload-artifact@v7
       with:
         name: digests-amd64
@@ -140,12 +170,14 @@ jobs:
       uses: docker/setup-buildx-action@v4
 
     - name: Login to the Docker Container Registry
+      if: needs.setup.outputs.is_fork != 'true'
       uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Login to the GitHub Container Registry
+      if: needs.setup.outputs.is_fork != 'true'
       uses: docker/login-action@v4
       with:
         registry: ghcr.io
@@ -153,6 +185,7 @@ jobs:
         password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Build and push (arm64)
+      if: needs.setup.outputs.is_fork != 'true'
       id: build
       uses: docker/build-push-action@v7
       with:
@@ -171,13 +204,31 @@ jobs:
           org.opencontainers.image.source=https://github.com/netbootxyz/docker-netbootxyz
         outputs: type=image,name=ghcr.io/netbootxyz/netbootxyz,push-by-digest=true,name-canonical=true,push=true
 
+    # Fork PRs cannot access registry secrets — verify the Dockerfile builds
+    # cleanly without pushing. Maintainers can manually trigger a publishing
+    # build via workflow_dispatch after reviewing the PR.
+    - name: Build (arm64, fork PR — no push)
+      if: needs.setup.outputs.is_fork == 'true'
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/arm64
+        push: false
+        build-args: |
+          WEBAPP_VERSION=${{ needs.setup.outputs.webapp_release }}
+          VERSION=${{ needs.setup.outputs.tag_suffix }}
+          BUILD_DATE=${{ needs.setup.outputs.build_date }}
+
     - name: Export digest
+      if: needs.setup.outputs.is_fork != 'true'
       run: |
         mkdir -p /tmp/digests
         digest="${{ steps.build.outputs.digest }}"
         touch "/tmp/digests/${digest#sha256:}"
 
     - name: Upload digest
+      if: needs.setup.outputs.is_fork != 'true'
       uses: actions/upload-artifact@v7
       with:
         name: digests-arm64
@@ -200,6 +251,7 @@ jobs:
 
   manifest:
     needs: [setup, build-amd64, build-arm64]
+    if: needs.setup.outputs.is_fork != 'true'
     runs-on: ubuntu-latest
     steps:
     - name: Set up Docker Buildx
@@ -247,7 +299,7 @@ jobs:
 
   comment:
     needs: [setup, manifest]
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && needs.setup.outputs.is_fork != 'true'
     runs-on: ubuntu-latest
     steps:
     - name: Comment on PR with test instructions
@@ -291,6 +343,46 @@ jobs:
           \`\`\`bash
           docker logs -f netbootxyz-test
           \`\`\`
+
+          ---
+          📦 **SHA:** \`${{ github.sha }}\`
+          🏷️ **Webapp Version:** \`${{ needs.setup.outputs.webapp_release }}\`
+          `;
+
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: comment
+          });
+
+  comment-fork:
+    needs: [setup, build-amd64, build-arm64]
+    if: github.event_name == 'pull_request' && needs.setup.outputs.is_fork == 'true'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Comment on fork PR with maintainer-trigger instructions
+      uses: actions/github-script@v8
+      with:
+        script: |
+          const comment = `## 🛠️ Build Verified (Fork PR)
+
+          The Dockerfile built cleanly on both \`linux/amd64\` and \`linux/arm64\`. ✅
+
+          No test image was pushed to a registry: GitHub deliberately withholds repository secrets from workflows triggered by fork PRs, so the build cannot authenticate to Docker Hub or GHCR. This is expected — not a bug in your PR.
+
+          ### For maintainers: publishing a test image for this PR
+
+          After reviewing the diff, push the PR head to a branch in this repo and the publishing build will run automatically:
+
+          \`\`\`bash
+          gh pr checkout ${{ github.event.number }}
+          git push origin HEAD:test/pr-${{ github.event.number }}
+          \`\`\`
+
+          Or trigger a one-off manually from the **Actions → build → Run workflow** menu after pushing the branch (optionally set \`tag_suffix\` to label the resulting image).
+
+          See [CONTRIBUTING.md](https://github.com/netbootxyz/docker-netbootxyz/blob/master/CONTRIBUTING.md) for details.
 
           ---
           📦 **SHA:** \`${{ github.sha }}\`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to docker-netbootxyz
+
+Thanks for your interest in contributing. This repo builds the official `netbootxyz/netbootxyz` container image.
+
+## Pull request CI
+
+The `build` workflow (`.github/workflows/build.yml`) runs on every PR against `master`. What happens depends on whether the PR is from a branch in this repo or from a fork.
+
+### Same-repo PRs
+
+PRs opened from a branch in `netbootxyz/docker-netbootxyz` get the full pipeline:
+
+1. Multi-arch build for `linux/amd64` and `linux/arm64`.
+2. Per-arch digests pushed to GitHub Container Registry.
+3. A multi-arch manifest pushed to both Docker Hub and GHCR, tagged `pr-<number>` and `pr-<number>-<sha>`.
+4. A comment is posted on the PR with `docker pull` / `docker run` instructions for testing the image.
+
+### Fork PRs
+
+PRs opened from a forked repo get a **build-only** verification:
+
+1. Multi-arch build for `linux/amd64` and `linux/arm64` (no push).
+2. A comment is posted on the PR confirming the build succeeded and pointing maintainers at the publish steps below.
+
+No image is pushed, because GitHub deliberately withholds repository secrets (Docker Hub / GHCR tokens) from workflow runs triggered by fork PRs. This is a security boundary — without it, any opened PR could exfiltrate the registry credentials.
+
+## Publishing a test image for a fork PR (maintainers)
+
+After reviewing the diff, push the PR head to a branch in this repo. That fires the same `build` workflow with secrets available, producing a `pr-<number>` test image:
+
+```bash
+gh pr checkout <PR-number>
+git push origin HEAD:test/pr-<PR-number>
+```
+
+The build will tag the resulting image `pr-<PR-number>` on both Docker Hub and GHCR. To clean up afterward, delete the test branch:
+
+```bash
+git push origin --delete test/pr-<PR-number>
+```
+
+### Alternative: `workflow_dispatch`
+
+The `build` workflow also accepts a manual trigger. From the **Actions → build → Run workflow** menu, pick a branch and optionally set `tag_suffix` to label the resulting image (e.g. `tag_suffix=fix-healthcheck` produces `test-fix-healthcheck`). Useful for one-off rebuilds of a branch without a PR.


### PR DESCRIPTION
## Summary
- Fork PRs (e.g. #108) can't access registry secrets, so the unconditional Docker Hub / GHCR login in `build.yml` always fails and red-X's every external contributor's CI. Gate login, push, manifest, and the existing test-image PR comment on a new `is_fork` output (computed by comparing `head.repo.full_name` to `github.repository`; `false` for same-repo PRs and `workflow_dispatch`).
- Fork PRs now run a single build-without-push step per arch as a Dockerfile smoke test, and get a separate `comment-fork` PR comment explaining why no image was published and pointing maintainers at the publish flow.
- New `CONTRIBUTING.md` documents same-repo vs fork CI paths and the maintainer publish flow (`gh pr checkout N` → `git push origin HEAD:test/pr-N`, plus the `workflow_dispatch` alternative with `tag_suffix`).

## Why
Currently any external contributor opens a PR → CI fails at `Login to the Docker Container Registry` with `Username and password required`. This is GitHub's deliberate secret-withholding for fork workflows working as designed, but the workflow doesn't account for it. After this change, external PRs get a clean green build-verified signal and contributors aren't left thinking their PR is broken.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Related Issues
Surfaces from #108 — fork PR where the login step fails.

## Testing

### Test Environment
- [x] Other: workflow YAML — verified locally by parsing as YAML (6 jobs present) and grepping that all 19 `is_fork` references gate the expected steps. Real validation needs this PR to actually run in CI (same-repo, so the full publish path exercises) and ideally a fresh fork PR after merge to exercise the build-only path.

### Test Results
```
$ ruby -ryaml -e 'd = YAML.load_file(".github/workflows/build.yml"); puts d["jobs"].keys'
setup
build-amd64
build-arm64
manifest
comment
comment-fork
```

## Checklist
- [x] My code follows the style of this project
- [x] I have tested my changes locally (YAML parses; structure verified)
- [ ] I have tested the automated PR build image (this PR is itself the test — full publish path runs since it's same-repo)
- [x] I have updated documentation (new CONTRIBUTING.md)
- [x] My changes generate no new errors or warnings

## Additional Notes
Intentionally did **not** switch the trigger to `pull_request_target`. That would run fork-supplied Dockerfile/build-args with credential access — exactly the supply-chain attack the `pull_request` trigger is designed to prevent. For a Docker-build repo this is a particularly sharp footgun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)