### PR TITLE
feat: download legacy USB bootloaders at init

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ The following bootfile names can be set as the boot file in the DHCP configurati
 | `netboot.xyz.efi` | UEFI boot image file, uses built-in UEFI NIC drivers |
 | `netboot.xyz-snp.efi` | UEFI w/ Simple Network Protocol, attempts to boot all net devices |
 | `netboot.xyz-snponly.efi` | UEFI w/ Simple Network Protocol, only boots from device chained from |
+| `netboot.xyz-legacy.kpxe` | Legacy BIOS boot image without USB NIC drivers; use if your USB keyboard stops working in the menu ([details](https://netboot.xyz/docs/kb/hardware/usb-keyboard/)) |
+| `netboot.xyz-legacy.efi` | UEFI boot image without USB NIC drivers; use if your USB keyboard stops working in the menu ([details](https://netboot.xyz/docs/kb/hardware/usb-keyboard/)) |
 | `netboot.xyz-arm64.efi` | DHCP EFI boot image file, uses built-in iPXE NIC drivers |
 | `netboot.xyz-arm64-snp.efi` | UEFI w/ Simple Network Protocol, attempts to boot all net devices |
 | `netboot.xyz-arm64-snponly.efi` | UEFI w/ Simple Network Protocol, only boots from device chained from |

--- a/root/init.sh
+++ b/root/init.sh
@@ -100,6 +100,19 @@ if [[ ! -f /config/menus/remote/menu.ipxe ]]; then
   curl -o \
     /config/menus/remote/netboot.xyz-arm64-snponly.efi -sL \
     "https://github.com/netbootxyz/netboot.xyz/releases/download/${MENU_VERSION}/netboot.xyz-arm64-snponly.efi"
+  # legacy boot files (no USB NIC drivers; preserve USB keyboard support on some
+  # BIOS/UEFI firmware -- https://netboot.xyz/docs/kb/hardware/usb-keyboard/).
+  # These assets only exist in 3.x and later releases, so download them only when
+  # the selected release provides them and skip gracefully otherwise.
+  for legacy_file in netboot.xyz-legacy.kpxe netboot.xyz-legacy.efi; do
+    if curl -o "/config/menus/remote/${legacy_file}" -fsSL \
+      "https://github.com/netbootxyz/netboot.xyz/releases/download/${MENU_VERSION}/${legacy_file}"; then
+      echo "[netbootxyz-init] Downloaded ${legacy_file}"
+    else
+      echo "[netbootxyz-init] ${legacy_file} not available for ${MENU_VERSION}, skipping"
+      rm -f "/config/menus/remote/${legacy_file}"
+    fi
+  done
   # layer and cleanup
   echo -n "${MENU_VERSION}" > /config/menuversion.txt
   cp -r /config/menus/remote/* /config/menus


### PR DESCRIPTION
## Summary

The container only downloaded the standard boot files at first start, so the `netboot.xyz-legacy.*` binaries — built **without USB NIC drivers** to preserve USB keyboard support on some BIOS/UEFI firmware — were never present in the TFTP root. Self-hosters hitting the USB-keyboard regression had no legacy binary to point DHCP at without manually adding it.

### Background

iPXE upstream commit [`2161e976`](https://github.com/ipxe/ipxe/commit/2161e976cdf78d0b26687e14f2cdc14008a99c83) enabled USB NIC drivers by default. On affected hardware, attaching those drivers disables the BIOS SMM-based USB legacy support (PS/2 keyboard emulation) or disconnects some UEFI vendor USB keyboard drivers, leaving the menu unresponsive. The main `netboot.xyz` build added `ipxe-legacy` fallback targets ([netboot.xyz#1777](https://github.com/netbootxyz/netboot.xyz/pull/1777)); this wires them into the container. Tracked in [netbootxyz/netboot.xyz#1769](https://github.com/netbootxyz/netboot.xyz/issues/1769).

## Changes

- **`root/init.sh`** — fetch `netboot.xyz-legacy.kpxe` and `netboot.xyz-legacy.efi` alongside the existing boot files. These assets only exist in 3.x+ releases, so they are downloaded with `curl -fsSL` and **skipped gracefully** (with a log line) when a pinned `MENU_VERSION` predates them.
- **`README.md`** — document both files in the boot-file-types table, linking to the KB article.

## Test plan

- [x] `bash -n root/init.sh` — parses cleanly
- [x] Legacy release URLs return HTTP 200 for `3.0.2`
- [x] Loop simulation: `3.0.2` downloads both files (389 KB / 1.1 MB); `2.0.89` (no legacy assets) skips gracefully with no leftover files and without failing init
- [ ] Build the image and confirm the legacy files land in `/config/menus` and are served over TFTP
- [ ] Boot an affected client with `netboot.xyz-legacy.efi` and confirm USB keyboard works

## Follow-up

Once this ships in a release, the self-hosted section of the [USB Keyboard KB article](https://netboot.xyz/docs/kb/hardware/usb-keyboard/) should be updated to note the container now provides these files.